### PR TITLE
Fix Monte Carlo UCT lambda bug and add regression test

### DIFF
--- a/techniques/monte_carlo.py
+++ b/techniques/monte_carlo.py
@@ -93,11 +93,16 @@ def monte_carlo_tree_search_uct(game_spec, board_state, side, number_of_samples)
                 result = 0
                 break
 
-            if all((state in state_samples) for _, state in move_states):
+            if all((state in state_samples) for state in move_states.values()):
                 log_total_samples = math.log(sum(state_samples[s] for s in move_states.values()))
-                move, state = max(move_states, key=lambda _, s: _upper_confidence_bounds(state_results[s],
-                                                                                         state_samples[s],
-                                                                                         log_total_samples))
+                move, state = max(
+                    move_states.items(),
+                    key=lambda item: _upper_confidence_bounds(
+                        state_results[item[1]],
+                        state_samples[item[1]],
+                        log_total_samples,
+                    ),
+                )
             else:
                 move = random.choice(list(move_states.keys()))
 

--- a/tests/techniques/test_monte_carlo.py
+++ b/tests/techniques/test_monte_carlo.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+
+from common.base_game_spec import BaseGameSpec
+from techniques.monte_carlo import monte_carlo_tree_search_uct
+
+
+class _LambdaBugGameSpec(BaseGameSpec):
+    def __init__(self):
+        pass
+
+    def new_board(self):
+        return 0
+
+    def apply_move(self, board_state, move, side):
+        return move[1]
+
+    def available_moves(self, board_state):
+        if board_state == 0:
+            return [(0, 1), (1, -1)]
+        return []
+
+    def has_winner(self, board_state):
+        return board_state
+
+    def board_dimensions(self):
+        return (1,)
+
+
+class TestMonteCarloTreeSearchUCT(TestCase):
+    def test_lambda_takes_single_argument(self):
+        game_spec = _LambdaBugGameSpec()
+        result, move = monte_carlo_tree_search_uct(game_spec, game_spec.new_board(), 1, 10)
+        self.assertIn(move, [(0, 1), (1, -1)])
+        self.assertIsInstance(result, float)


### PR DESCRIPTION
## Summary
- fix the lambda expression in `monte_carlo_tree_search_uct`
- add regression test covering the bug

## Testing
- `python -m unittest tests.techniques.test_monte_carlo -v`
